### PR TITLE
[Quick Start Guide] retouch with redirectUrl info

### DIFF
--- a/docs/quick-start-guide.mdx
+++ b/docs/quick-start-guide.mdx
@@ -140,7 +140,7 @@ You can implement any of the following:
     </p>
   </details>
     
-  The user will either have matching credentials, or they won't. If they do, continue to step (2). If they don't, you're done with Unum ID and should take the user through your existing verification flow.
+  The user will either have matching credentials, or they won't. If they do, continue to step (2). If they don't, you're done with Unum ID and should take the user through your existing verification flow. <i>If you would like your existing verification flow verification costs to be covered, please look into the <b>Both</b> section of this quick start, which includes both Free IDV and 1-Click IDV.</i>
 
   2. **Direct the user to the `url`** the response body contains with an additional `redirectUrl` query param that you define which will serve as the ultimate landing page after the user completes 1-Click IDV from the Unum ID web wallet. For example the final url you need to redirect the user to is:
 


### PR DESCRIPTION
[Ticket](https://trello.com/c/OBAqmkii/4761-renewed-documentation-effort-in-regard-to-credential-re-use)

## Summary
Cleaned up the quick start guide for clarity and typos. Also, added a necessary step in regard to how to define the `redirectUrl` that the wallet will direct the user to post 1-click idv.

## Changes
- fix how to handle if match.
- refactor ordering of drop downs
- backend mention in quick start
- both fix
- free sales pitch after 1-click no match

## Testing
- locally viewed the web pages

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
~- [ ] If it is a core feature, I have added an appropriate amount of unit tests.~
- [x] Any dependent changes have been merged and published in upstream projects