### PR TITLE
[Core-Types] typedoc links removed in favor linking to code-snippets.

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -84,7 +84,7 @@ You need to provide:
 7. (Optional) isHosted. _If you would like to do the [non-hosted](/#non-hosted-flow) integration ._
 8. (Optional) User's birthDate. _Only required if you are using the [non-hosted](/#non-hosted-flow) integration._
 
-A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](https://docs.verified.inc/core-types/interfaces/CredentialRequestDto.html) objects.
+A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](/reusables/credential-request-code-snippet) objects.
 
 <CredentialRequestCodeSnippet />
 
@@ -148,7 +148,7 @@ You need to provide:
 3. (Optional) User's email.
 4. (Optional) Credential request(s). _If you would like to update from the default credential requests._
 
-A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](https://docs.verified.inc/core-types/interfaces/CredentialRequestDto.html) objects.
+A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](/reusables/credential-request-code-snippet) objects.
 
 <CredentialRequestCodeSnippet />
 
@@ -401,7 +401,7 @@ You need to provide:
 3. (Optional) Partner UUID. _More information on the partner UUID use case can be found in the [Issuance Guide](/issuance-guide#already-issued-credentials)._
 4. (Optional) List of the sub-credentials that make up the credential. _If not provided, all sub-credentials will be returned._
 
-A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](https://docs.verified.inc/core-types/interfaces/CredentialRequestDto.html) objects.
+A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](/reusables/credential-request-code-snippet) objects.
 
 <CredentialRequestCodeSnippet />
 


### PR DESCRIPTION
## Summary
[Core-Types] typedoc links removed in favor linking to code-snippets.
