### PR TITLE
fix typo in get endpoint

### DIFF
--- a/versioned_docs/version-2/1-click-signup/api-reference/endpoints.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/endpoints.mdx
@@ -211,7 +211,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
   </tr>
   <tr>
     <th>Path</th>
-    <td>`/1-click/{uuid}?{userInput}`</td>
+    <td>`/1-click/{uuid}?code={userInput}`</td>
   </tr>
 </table>
 
@@ -232,7 +232,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
     <IntegrationTypeAdmonition option="Semi-Hosted"/>
     Call:
     ```json title="GET /1-click Request (Semi-Hosted Integration Type)"
-    GET /1-click/{uuid}?{userInput}
+    GET /1-click/{uuid}?code={userInput}
     ```
     - For the `{uuid}` endpoint path parameter, use the value of `uuid` from the [response body of `POST /1-click`](#post-1-click-response).
     - For the `{userInput}` endpoint URL parameter, use the value the user inputted when you prompted them to enter their verification code.

--- a/versioned_docs/version-2/1-click-signup/integration-guide.mdx
+++ b/versioned_docs/version-2/1-click-signup/integration-guide.mdx
@@ -296,7 +296,7 @@ If you _do_ include `credentialRequests` in the request body of `POST /1-click`,
 
     ### 5. Call `GET /1-click`.
 
-    Call [`GET /1-click/{uuid}?{userInput}`](./endpoints?integrationType=semi-hosted#get-1-click) with `uuid` from the [response body of `POST /1-click`](./endpoints?integrationType=semi-hosted#post-1-click-response) and `userInput`.
+    Call [`GET /1-click/{uuid}?code={userInput}`](./endpoints?integrationType=semi-hosted#get-1-click) with `uuid` from the [response body of `POST /1-click`](./endpoints?integrationType=semi-hosted#post-1-click-response) and `userInput`.
 
     <UseUserInputAdmonition/>
 

--- a/versioned_docs/version-2/1-click-signup/migration-guide-v1-to-v2.mdx
+++ b/versioned_docs/version-2/1-click-signup/migration-guide-v1-to-v2.mdx
@@ -229,7 +229,7 @@ Migrating from v1 to v2 is simple and easy. How to do so depends on which varian
     #### c. Update `GET /1-click`.
 
     **Request:**
-    - **Add `userInput` as a parameter** to call [`GET /1-click/{uuid}?{userInput}`](./endpoints?integrationType=semi-hosted#get-1-click).
+    - **Add `userInput` as a parameter** to call [`GET /1-click/{uuid}?code={userInput}`](./endpoints?integrationType=semi-hosted#get-1-click).
         - In v1, you append what the user inputs for the verification code (let's call it `userInput`) to `url` and then redirect the user to the resulting link, which verifies the user's input and then redirects them back to you.
         - In v2, you instead include `userInput` as a parameter on the `GET /1-click` API call. There's no need for a redirect.
 


### PR DESCRIPTION
## Summary
Fix typo by adding 'code=' in 'GET /1-click/{uuid}?{userInput}'

[Ticket](<!-- link to ticket -->)
https://verified-inc.slack.com/lists/TD0LFET2P/F07D02R65QC?record_id=Rec07TG5QH25A
## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
Locally

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects