### PR TITLE
[Liam] Clarify multiple data types and add info about metadata order

### DIFF
--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -240,7 +240,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
         [credentialKey: string]: 
             string     // Single string value when `multi` is false and `children` isn't included in the credential requests
             | [string] // Array of string values when `multi` is true and `children` isn't included in the credential requests
-            | Object   // Single credential value of type `Object` when `children` is present and `multi` is false
+            | Object   // Single object value when `multi` is false and `children` is included in the credential requests
             | [Object] // Array of credential values of type `Object` when `multi` is true and `children` is present
     },
     "metadata": {

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -237,7 +237,11 @@ See also our [Postman docs](https://api.docs.verified.inc/).
         [identifierKey: string]: string
     },
     "credentials": {
-        [credentialKey: string]: string | [string] | Object | [Object]
+        [credentialKey: string]: 
+            string     // Single credential value when `children` is not present and `multi` is false
+            | [string] // Array of credential values when `multi` is true, but no `children`
+            | Object   // Single credential value of type `Object` when `children` is present and `multi` is false
+            | [Object] // Array of credential values of type `Object` when `multi` is true and `children` is present
     },
     "metadata": {
         "identifiers": {

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -238,7 +238,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
     },
     "credentials": {
         [credentialKey: string]: 
-            string     // Single credential value when `children` is not present and `multi` is false
+            string     // Single string value when `multi` is false and `children` isn't included in the credential requests
             | [string] // Array of credential values when `multi` is true, but no `children`
             | Object   // Single credential value of type `Object` when `children` is present and `multi` is false
             | [Object] // Array of credential values of type `Object` when `multi` is true and `children` is present

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -251,6 +251,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
         },
         "credentials": {
             [credentialKey: string]: {
+                // Follows the same structure as `credentials` and maintains the same order for array items when `multi` is set to `true`
                 [metadataKey: string]: string | [string] | Object | [Object]
             }
         }

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -239,7 +239,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
     "credentials": {
         [credentialKey: string]: 
             string     // Single string value when `multi` is false and `children` isn't included in the credential requests
-            | [string] // Array of credential values when `multi` is true, but no `children`
+            | [string] // Array of string values when `multi` is true and `children` isn't included in the credential requests
             | Object   // Single credential value of type `Object` when `children` is present and `multi` is false
             | [Object] // Array of credential values of type `Object` when `multi` is true and `children` is present
     },

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -241,7 +241,7 @@ See also our [Postman docs](https://api.docs.verified.inc/).
             string     // Single string value when `multi` is false and `children` isn't included in the credential requests
             | [string] // Array of string values when `multi` is true and `children` isn't included in the credential requests
             | Object   // Single object value when `multi` is false and `children` is included in the credential requests
-            | [Object] // Array of credential values of type `Object` when `multi` is true and `children` is present
+            | [Object] // Array of object values when `multi` is true and `children` is included in the credential requests
     },
     "metadata": {
         "identifiers": {

--- a/versioned_docs/version-2/reusables/1-click-entity-example.mdx
+++ b/versioned_docs/version-2/reusables/1-click-entity-example.mdx
@@ -47,8 +47,10 @@
                 "phone": "otp"
             }
         },
+        // Follows the same structure as `credentials` and maintains the same order for array items when `multi` is set to `true`
         "credentials": {
             "id": {
+                // e.g. Follows the same structure as the email credential and maintains the same order for array items
                 "email": [
                     "8a1d4e35-413d-496b-b499-8810b55cfb5c",
                     "b82e39cf-3bb6-4105-b9c1-bfd1ed2a4dbc"
@@ -57,6 +59,7 @@
                     "firstName": "2e6a7b9a-e93e-43ba-98a9-c554f4e16457",
                     "lastName": "9a5817ef-e621-4277-8c48-c8ee3776b6c4"
                 },
+                // e.g. Follows the same structure as the address credential and maintains the same order for array items
                 "address": [
                     {
                         "line1": "f5a4dc93-bc06-4bb8-bd05-17b5ba912bcd",


### PR DESCRIPTION
Clarify multiple data types and add info about metadata order

**1-Click Type definition**
![image](https://github.com/user-attachments/assets/ac03b89e-3ff8-45cb-88d9-fbd804c3331e)

**1-Click Example**
![image](https://github.com/user-attachments/assets/29d8bbdb-30cc-43ca-a1d2-57ced92a3336)


[Ticket](<!-- link to ticket -->)
<!---
The link to the Trello ticket for this work is below.
--->
- https://verified-inc.slack.com/lists/TD0LFET2P/F07D02R65QC?record_id=Rec07PUTUA0CD
- https://verified-inc.slack.com/lists/TD0LFET2P/F07D02R65QC?record_id=Rec07PR4H98K0

## Changes
- Add comment to lines with multiple data types in 1ClickEntity type definition (to clarify behavior based on multi)
- Add info about values in arrays (when multi is enabled) being in the same order for credentials and credential metadata

## Testing
locally

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects