### PR TITLE
multi max length and not working on children

### DIFF
--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -562,7 +562,10 @@ The data keyed on a `credentialKey` will be one or more credential values. This 
             ```
         </details>
         <Admonition type="warning" title="Arrays May Be Single Valued">
-            **An array of credential values may only include one value.** If `multi` is set to `true` in a credential request, we'll return multiple values _if_ we can source them. But if we can only source a single value, we'll still return it in an array, to ensure the data type is predictable.
+            **An array of credential values may only include one value.** If `multi` is set to `true` in a credential request, we'll return multiple values _if_ we can source them (up to a maximum of 3). But if we can only source a single value, we'll still return it in an array, to ensure the data type is predictable.
+        </Admonition>
+        <Admonition type="info" title="Multi Does Not Apply to Child Credential Requests">
+            **The `multi` option does not work on `children` credential requests.** It only applies to the parent credential request.
         </Admonition>
     - If the credential request has `multi` set to `false`, the data keyed on `credentialKey` will be a single credential value. 
         <details>

--- a/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/types.mdx
@@ -562,7 +562,7 @@ The data keyed on a `credentialKey` will be one or more credential values. This 
             ```
         </details>
         <Admonition type="warning" title="Arrays May Be Single Valued">
-            **An array of credential values may only include one value.** If `multi` is set to `true` in a credential request, we'll return multiple values _if_ we can source them (up to a maximum of 3). But if we can only source a single value, we'll still return it in an array, to ensure the data type is predictable.
+            **An array of credential values may only include one value.** If `multi` is set to `true` in a credential request, we'll return multiple values _if_ we can source them (**up to a maximum of 3**). But if we can only source a single value, we'll still return it in an array, to ensure the data type is predictable.
         </Admonition>
         <Admonition type="info" title="Multi Does Not Apply to Child Credential Requests">
             **The `multi` option does not work on `children` credential requests.** It only applies to the parent credential request.


### PR DESCRIPTION
… values

## Summary
Clarify that "multi" applies only to parent credentials and can have a maximum of 3 values

![image](https://github.com/user-attachments/assets/55b882f0-d2a3-4176-8c3c-edc45a8ab9ad)


[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->
- https://verified-inc.slack.com/lists/TD0LFET2P/F07D02R65QC?record_id=Rec07PXPKN950
- https://verified-inc.slack.com/lists/TD0LFET2P/F07D02R65QC?record_id=Rec07Q0858X8C

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects