### PR TITLE
fix: two collapsable bugs

### DIFF
--- a/src/components/Collapsable.jsx
+++ b/src/components/Collapsable.jsx
@@ -133,7 +133,7 @@ export const CollapsableGroup = ({ children, firstSectionExpanded = true }) => {
 
         });
 
-    }, [children]);
+    }, []);
 
     // Should render if firstSectionExpanded is false or the default expanded section was already loaded
     // This is to avoid any transition animation when the first section is expanded by default

--- a/versioned_docs/version-2/1-click-signup/api-reference/errors.mdx
+++ b/versioned_docs/version-2/1-click-signup/api-reference/errors.mdx
@@ -95,7 +95,9 @@ An `errorCode` is a Verified specific error code consisting of 3 letters and 3 n
 
 
   </CollapsableSection>
+</CollapsableGroup>
 
+<CollapsableGroup>
 
   <CollapsableSection>
     <CollapsableHeader>


### PR DESCRIPTION
## Summary
<!---
1-2 sentences summarizing the changes included in this PR
--->
bug where collapsable re-renders with children changes. And separate errors sections into two different section groups

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->
- The first bug was causing the collapsable section to close when tabs were changed
- The second "bug" didn't allow the error's to be clicked. This is more of a workaround than a fix
## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects