### PR TITLE
chore: keep only 5 digits zipcode version

### DIFF
--- a/versioned_docs/version-2.1/1-click-signup/data/outputs/credentials.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/data/outputs/credentials.mdx
@@ -168,9 +168,9 @@ We can source verified KYC type data for **~95% of US adults.** Coverage for you
         <td>↳ ZIP Code</td>
         <td>`address.zipCode`</td>
         <td>`string`</td>
-        <td>[ZIP Code](https://en.wikipedia.org/wiki/ZIP_Code) (5 digits, 0-9) or [ZIP+4](https://en.wikipedia.org/wiki/ZIP_Code#ZIP+4) (9 digits, 0-9, with a hypen after the first 5)</td>
+        <td>[ZIP Code](https://en.wikipedia.org/wiki/ZIP_Code) (5 digits, 0-9)</td>
         <td>ZIP code of address</td>
-        <td>`"94303"` or `"94303-3058"`</td>
+        <td>`"94303"`</td>
     </tr>
     <tr>
         <td>↳ Country</td>


### PR DESCRIPTION
## Summary
Keep only 5 digits Zipcode credential version.

## Changes
- updated Data > Outputs > Credentials

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
