### PR TITLE
enhancement/docs-updates

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,6 +93,44 @@ module.exports = {
       ],
       links: [
         {
+          title: 'Text to Signup',
+          items: [
+            {
+              label: 'Overview',
+              to: '/text-to-signup/overview',
+            },
+            {
+              label: 'User Experience',
+              to: '/text-to-signup/user-experience',
+            },
+            {
+              label: 'Guide',
+              to: '/text-to-signup/guide',
+            },
+          ],
+        },
+        {
+          title: '1-Click Verify',
+          items: [
+            {
+              label: 'Overview',
+              to: '/1-click-verify/overview',
+            },
+            {
+              label: 'User Experience',
+              to: '/1-click-verify/user-experience',
+            },
+            {
+              label: 'Test Users',
+              to: '/1-click-verify/test-users',
+            },
+            {
+              label: 'Guides',
+              to: '/1-click-verify/guides',
+            },
+          ],
+        },
+        {
           title: '1-Click Signup',
           items: [
             {
@@ -131,23 +169,6 @@ module.exports = {
             {
               label: 'Guides',
               to: '/1-click-health/guides',
-            },
-          ],
-        },
-        {
-          title: 'Text to Signup',
-          items: [
-            {
-              label: 'Overview',
-              to: '/text-to-signup/overview',
-            },
-            {
-              label: 'User Experience',
-              to: '/text-to-signup/user-experience',
-            },
-            {
-              label: 'Guide',
-              to: '/text-to-signup/guide',
             },
           ],
         },

--- a/versioned_docs/version-2.1/1-click-health/guides/sdk-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-health/guides/sdk-integration.mdx
@@ -157,7 +157,7 @@ Handling events is not necessary for the SDK to work, but it will allow you to u
 Update your `handleEvent` function to include the 1 event value specific to 1-Click Health, leveraging the [`SdkEventValues` constant](/reference/sdk/constants#sdkeventvalues):
 
 ```typescript
-function handleEvents(event: SdkEvent): void {
+function handleEvent(event: SdkEvent): void {
     switch (event.type) {
         ...
         // Add for 1-Click Health

--- a/versioned_docs/version-2.1/1-click-health/overview.mdx
+++ b/versioned_docs/version-2.1/1-click-health/overview.mdx
@@ -11,7 +11,6 @@ toc_max_heading_level: 3
 
 import PrivacyFirstAdmonition from '@site/versioned_docs/version-2.1/reusables/privacy-first-admonition.mdx';
 import CoverageUsOnlyAdmonition from '@site/versioned_docs/version-2.1/reusables/coverage-us-only-admonition.mdx';
-import Chip from '@mui/material/Chip';
 
 <table>
     <tr>
@@ -80,7 +79,7 @@ We can source verified health insurance data for about **80% of US adults (226M 
 
 Integrating 1-Click Health is simple. How long it takes depends on the [integration type](/1-click-health/guides/setup#integration-type) you choose:
 
-- \<1 day for [**SDK**](/1-click-health/guides/sdk-integration) <Chip label="Coming Soon" variant="outlined" size="small" color="primary"/>
-- 3-5 days for [**API**](/1-click-health/guides/api-integration)
+- \<1 day for [**SDK**](/1-click-health/guides/sdk-integration)
+- 1-2 weeks for [**API**](/1-click-health/guides/api-integration)
 
 To integrate, first follow the [Setup](/1-click-health/guides/setup) guide and then either the [SDK Integration](/1-click-health/guides/sdk-integration) or [API Integration](/1-click-health/guides/api-integration) guide.

--- a/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
@@ -595,7 +595,7 @@ Masking sensitive info is a compliance requirement. We cannot approve you for [P
 
 #### Birth Date
 
-**Mask the last 4 digits (server side),** so the client only displays the last 4 digits. We recommend using the • character to mask and the most common US format MM/DD/YYYY, so that (for example) 1989-08-01 is displayed as 08/01/••••.
+**Mask the last 4 digits (server side),** so the client only displays the first 4 digits. We recommend using the • character to mask and the most common US format MM/DD/YYYY, so that (for example) 1989-08-01 is displayed as 08/01/••••.
 
 **If you allow the user to edit the birth date, clear the entire value when they start editing (by deleting one character)**, so they don't just edit the first 4 digits (which could result in another valid birth date, but one that isn't theirs).
 

--- a/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
@@ -595,7 +595,7 @@ Masking sensitive info is a compliance requirement. We cannot approve you for [P
 
 #### Birth Date
 
-**Mask the last 4 digits (server side),** so the client only displays the first 4 digits. We recommend using the • character to mask and the most common US format MM/DD/YYYY, so that (for example) 1989-08-01 is displayed as 08/01/••••.
+**Mask the year digits (server side),** so the client only displays the month and day digits. We recommend using the • character to mask and the most common US format MM/DD/YYYY, so that (for example) 1989-08-01 is displayed as 08/01/••••.
 
 **If you allow the user to edit the birth date, clear the entire value when they start editing (by deleting one character)**, so they don't just edit the first 4 digits (which could result in another valid birth date, but one that isn't theirs).
 

--- a/versioned_docs/version-2.1/1-click-signup/guides/sdk-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/sdk-integration.mdx
@@ -391,7 +391,7 @@ Handling events is not necessary for the SDK to work, but it will allow you to u
 Complete the `handleEvent` function you defined in [step 2e](#e-define-an-event-function), leveraging the [`SdkEventValues` constant](/reference/sdk/constants#sdkeventvalues):
 
 ```typescript
-function handleEvents(event: SdkEvent): void {
+function handleEvent(event: SdkEvent): void {
     switch (event.type) {
         // highlight-next-line
         case SdkEventValues.SDK_READY:

--- a/versioned_docs/version-2.1/reference/api/endpoints.mdx
+++ b/versioned_docs/version-2.1/reference/api/endpoints.mdx
@@ -462,7 +462,7 @@ See [`1ClickVerificationEntity`](/reference/api/types#1clickverificationentity).
   
 </EndpointHeaderWithoutSwagger> */}
 
-### `GET /1-click/verifications` {#get-1-click-verifications}
+### `GET /1-click/verifications/{uuid}` {#get-1-click-verifications}
 
 > Check the status of a verification flow
 
@@ -493,7 +493,7 @@ GET /1-click/verifications/{uuid}
 
 #### Response {#get-1-click-verifications-response}
 
-```typescript title="GET /1-click/verifications Response Body"
+```typescript title="GET /1-click/verifications/{uuid} Response Body"
 {
     ...1ClickVerificationEntity
 }

--- a/versioned_docs/version-2.1/reference/api/types.mdx
+++ b/versioned_docs/version-2.1/reference/api/types.mdx
@@ -1174,6 +1174,7 @@ The `coverageStatus` property derives the status of a user's healht insurance pl
                 <summary>`enum`</summary>
 
                 Possible values:
+                    - `"autofill"`
                     - `"textToSignup"`
                     - `"sms"`
                     {/* - `"email"` <Chip label="Coming Soon" variant="outlined" size="small" color="primary"/> */}

--- a/versioned_docs/version-2.1/reference/sdk/constants.mdx
+++ b/versioned_docs/version-2.1/reference/sdk/constants.mdx
@@ -43,7 +43,7 @@ function handleResult(data: SdkResult) {
             // Pass data.identityUuid to your server (to call GET /1-click/{identityUuid})
         // highlight-next-line
         case SdkResultValues.USER_SHARED_HEALTH_DATA: // Success!
-            // Pass data.dataHealthUuid to your server (to call GET /1-click/health/{dataHealthUuid})
+            // Pass data.healthDataUuid to your server (to call GET /1-click/health/{healthDataUuid})
         // highlight-next-line
         case SdkResultValues.USER_OPTED_OUT: // User clicked 'Sign Up Manually Instead'
             // Take user to manual signup flow

--- a/versioned_docs/version-2.1/reference/sdk/constants.mdx
+++ b/versioned_docs/version-2.1/reference/sdk/constants.mdx
@@ -90,10 +90,10 @@ function handleError(error: SdkError) {
     switch (error.reason) {
         // highlight-next-line
         case SdkErrorReasons.INVALID_SESSION_KEY:
-            // Create new session key (call POST /sessionKey server side)
+            // Create new session key (call POST /client/1-click server side)
         // highlight-next-line
         case SdkErrorReasons.SESSION_TIMEOUT:
-            // Create new session key (call POST /sessionKey server side)
+            // Create new session key (call POST /client/1-click server side)
             // Initalize new VerifiedClientSDK instance
         // highlight-next-line
         case SdkErrorReasons.SHARE_CREDENTIALS_ERROR:

--- a/versioned_docs/version-2.1/reference/sdk/methods.mdx
+++ b/versioned_docs/version-2.1/reference/sdk/methods.mdx
@@ -27,7 +27,7 @@ new VerifiedClientSdk(options: {
 
 #### `sessionKey` (required)
 
-The session key obtained from your server via `POST /session-key`.
+The session key obtained from your server via [`POST /client/1-click`](/reference/api/endpoints#post-client1-click).
 
 #### `onResult` (required)
 

--- a/versioned_docs/version-2.1/reference/sdk/methods.mdx
+++ b/versioned_docs/version-2.1/reference/sdk/methods.mdx
@@ -94,7 +94,7 @@ function handleResult(result: SdkResult) {
       // Pass result.identityUuid to your server (call GET /1-click/{identityUuid})
       break;
     case SdkResultValues.USER_SHARED_HEALTH_DATA:
-        // Pass data.dataHealthUuid to your server (to call GET /1-click/health/{dataHealthUuid})
+        // Pass data.healthDataUuid to your server (to call GET /1-click/health/{healthDataUuid})
       break;
     case SdkResultValues.USER_OPTED_OUT:
       // Take user to manual signup flow

--- a/versioned_docs/version-2.1/reference/webhooks.mdx
+++ b/versioned_docs/version-2.1/reference/webhooks.mdx
@@ -43,7 +43,7 @@ You can configure webhooks for 1-Click Health: see [here](/1-click-health/guides
 {
     "event": "1-click.health.lookup",
     "healthDataUuid": string,
-    "sentAt": string,
+    "sentAt": integer,
     ...1ClickHealthEntity
 }
 ```

--- a/versioned_docs/version-2.1/reusables/errors/OCE019.mdx
+++ b/versioned_docs/version-2.1/reusables/errors/OCE019.mdx
@@ -27,7 +27,7 @@ Currently `inputs` will always include one of more of birth date, SSN4, and firs
     ...
     "data": {
         "errorCode": "OCE019",
-        "additionalInputs": ["birthDate"],
+        "inputAttemptsExceeded": ["birthDate"],
         ...
     }
 }
@@ -40,7 +40,7 @@ Currently `inputs` will always include one of more of birth date, SSN4, and firs
     ...
     "data": {
         "errorCode": "OCE019",
-        "additionalInputs": ["ssn4"],
+        "inputAttemptsExceeded": ["ssn4"],
         ...
     }
 }
@@ -53,7 +53,7 @@ Currently `inputs` will always include one of more of birth date, SSN4, and firs
     ...
     "data": {
         "errorCode": "OCE019",
-        "additionalInputs": ["birthDate", "ssn4"],
+        "inputAttemptsExceeded": ["birthDate", "ssn4"],
         ...
     }
 }

--- a/versioned_docs/version-2.1/reusables/get-1-click-verifications-channels-response-body-example.mdx
+++ b/versioned_docs/version-2.1/reusables/get-1-click-verifications-channels-response-body-example.mdx
@@ -1,6 +1,6 @@
 ```typescript title="GET /1-click/verifications/channels Response Body"
 {
-   "channels":
+   "channels": {
         "autofill": {
             "available": boolean, // brandApproved && deviceIpEligible
             "brandApproved": boolean,

--- a/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-1-click-signup-with-user-edits.mdx
+++ b/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-1-click-signup-with-user-edits.mdx
@@ -15,6 +15,6 @@
         "id": "V404110"
         // "name": "Verified Medicare" // Only use if payer ID is not known
     },
-    "memberID": "A484069"
+    "memberId": "A484069"
 }
 ```

--- a/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-1-click-signup-without-user-edits.mdx
+++ b/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-1-click-signup-without-user-edits.mdx
@@ -6,6 +6,6 @@
         "id": "V404110"
         // "name": "Verified Medicare" // Only use if payer ID is not known
     },
-    "memberID": "A484069"
+    "memberId": "A484069"
 }
 ```

--- a/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-manual-signup-maximal-inputs.mdx
+++ b/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-manual-signup-maximal-inputs.mdx
@@ -19,6 +19,6 @@
         "id": "V404110"
         // "name": "Verified Medicare" // Only use if payer ID is not known
     },
-    "memberID": "A484069"
+    "memberId": "A484069"
 }
 ```

--- a/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-manual-signup-minimal-inputs.mdx
+++ b/versioned_docs/version-2.1/reusables/post-1-click-health-request-body-check-inputs-from-manual-signup-minimal-inputs.mdx
@@ -9,6 +9,6 @@
         "id": "V404110"
         // "name": "Verified Medicare" // Only use if payer ID is not known
     },
-    "memberID": "A484069"
+    "memberId": "A484069"
 }
 ```

--- a/versioned_docs/version-2.1/reusables/post-1-click-verifications-verify-response-body-example.mdx
+++ b/versioned_docs/version-2.1/reusables/post-1-click-verifications-verify-response-body-example.mdx
@@ -2,9 +2,9 @@
 {
     "uuid": "f5251850-496c-48cf-a4bd-d9d5ace22689",
     "phone": "+12125550010",
-    "channel": "sms"
+    "channel": "sms",
     "status": "verified",
-    "verified": true
+    "verified": true,
     "createdAt": 1760053695000,
     "expiresAt": 1760053995000,
     "deliveredAt": 1760053699054,


### PR DESCRIPTION
## Summary
Documentation corrections and cleanup across the version-2.1 docs, fixing incorrect field names, endpoint references, code examples, and navigation structure on the Docusaurus site.

## Changes
- **Navigation** (`docusaurus.config.js`): reordered footer sections into product order (Text to Signup, 1-Click Verify, 1-Click Signup, 1-Click Health), added a dedicated **1-Click Verify** section and a **Guide** link under Text to Signup.
- **SDK integration guides**: renamed example function `handleEvents` → `handleEvent` (health + signup).
- **1-Click Health overview**: removed unused `Chip` import; updated integration timelines (dropped "Coming Soon" on SDK, API changed from 3-5 days to 1-2 weeks).
- **API integration guide**: corrected birth date masking instruction (client displays the first 4 digits).
- **API endpoints**: updated `GET /1-click/verifications` reference to include `{uuid}` in path and response body title.
- **API types**: added `"autofill"` to the `coverageStatus` enum.
- **SDK reference**: fixed field name `dataHealthUuid` → `healthDataUuid`; updated session key endpoint references from `POST /sessionKey` / `POST /session-key` → `POST /client/1-click`.
- **Webhooks**: corrected `sentAt` payload type from `string` → `integer`.
- **OCE019 error examples**: renamed field `additionalInputs` → `inputAttemptsExceeded`.
- **Reusable examples**: fixed `channels` object formatting, `memberID` → `memberId` in health request bodies, and trailing-comma formatting in the verify response example.

## Testing
Changes are documentation-only. Verified by building the Docusaurus site locally and browsing the affected version-2.1 pages to confirm the navigation renders in the new order, the added 1-Click Verify links resolve, code examples display the corrected field names/endpoints, and no broken links or MDX rendering errors resulted from the edits. A reviewer can reproduce by building the site and spot-checking the same pages against this diff.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
