### PR TITLE
enhancement/docs-revisions

### DIFF
--- a/src/components/Collapsible.jsx
+++ b/src/components/Collapsible.jsx
@@ -47,6 +47,7 @@ export const CollapsibleSection = ({ activeId, setActiveId, id, children }) => {
   const rootRef = useRef(null);
   const bodyRef = useRef(null);
   const { hash } = useLocation();
+
   const header = React.Children.toArray(children).find(
     (child) => child.type === CollapsibleHeader
   );
@@ -57,23 +58,35 @@ export const CollapsibleSection = ({ activeId, setActiveId, id, children }) => {
 
   const handleClick = (e) => {
     // Don’t toggle if the user clicked the built-in Docusaurus hash icon/link
-    if (e.target.classList?.contains('hash-link')) return;
+    if (e.target.classList?.contains('hash-link')) {
+      return;
+    }
+
     setActiveId(isActive ? undefined : id);
   };
 
   // Find the first rendered heading inside this section (h1–h6) and read its id.
   const getHeadingId = () => {
     const el = rootRef.current;
-    if (!el) return null;
+
+    if (!el) {
+      return null;
+    }
+
     const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+
     return heading?.id || null;
   };
 
   // When the URL hash matches our heading id, open this section.
   useEffect(() => {
-    if (!hash) return;
+    if (!hash) {
+      return;
+    }
+
     const current = hash.replace(/^#/, '');
     const myHeadingId = getHeadingId();
+
     if (myHeadingId && current === myHeadingId) {
       setActiveId(id); // group will scroll after state update
     }

--- a/src/components/Collapsible.jsx
+++ b/src/components/Collapsible.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useId, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from '@docusaurus/router';
-import { ExpandLess, ExpandMore } from "@mui/icons-material";
-import { Box } from "@mui/material";
-import AnchorOffset from '@site/src/components/AnchorOffset.jsx'
-
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { Box } from '@mui/material';
+import AnchorOffset from '@site/src/components/AnchorOffset.jsx';
 
 /**
  * This is used to create collapsible sections. It allows one section per group to be open at a time.
@@ -36,159 +35,207 @@ import AnchorOffset from '@site/src/components/AnchorOffset.jsx'
     </CollapsibleGroup>
  */
 
-
 export const CollapsibleHeader = ({ children, isActive }) => (
-    <div className='collapsible-header'>
-        {isActive ? <ExpandLess /> : <ExpandMore />}
-        {children}
-    </div>
+  <div className='collapsible-header'>
+    {isActive ? <ExpandLess /> : <ExpandMore />}
+    {children}
+  </div>
 );
 
 export const CollapsibleSection = ({ activeId, setActiveId, id, children }) => {
-    const isActive = id === activeId;
-    const rootRef = useRef(null);
-    const { hash } = useLocation();
-    const header = React.Children.toArray(children).find(
-        (child) => child.type === CollapsibleHeader
-    );
+  const isActive = id === activeId;
+  const rootRef = useRef(null);
+  const bodyRef = useRef(null);
+  const { hash } = useLocation();
+  const header = React.Children.toArray(children).find(
+    (child) => child.type === CollapsibleHeader
+  );
 
-    const body = React.Children.toArray(children).filter(
-        (child) => child.type !== CollapsibleHeader
-    );
+  const body = React.Children.toArray(children).filter(
+    (child) => child.type !== CollapsibleHeader
+  );
 
+  const handleClick = (e) => {
+    // Don’t toggle if the user clicked the built-in Docusaurus hash icon/link
+    if (e.target.classList?.contains('hash-link')) return;
+    setActiveId(isActive ? undefined : id);
+  };
 
-    const handleClick = (e) => {
-        // Don’t toggle if the user clicked the built-in Docusaurus hash icon/link
-        if (e.target.classList?.contains('hash-link')) return;
-        setActiveId(isActive ? undefined : id);
-    };
+  // Find the first rendered heading inside this section (h1–h6) and read its id.
+  const getHeadingId = () => {
+    const el = rootRef.current;
+    if (!el) return null;
+    const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+    return heading?.id || null;
+  };
 
-    // Find the first rendered heading inside this section (h1–h6) and read its id.
-    const getHeadingId = () => {
-        const el = rootRef.current;
-        if (!el) return null;
-        const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
-        return heading?.id || null;
-    };
+  // When the URL hash matches our heading id, open this section.
+  useEffect(() => {
+    if (!hash) return;
+    const current = hash.replace(/^#/, '');
+    const myHeadingId = getHeadingId();
+    if (myHeadingId && current === myHeadingId) {
+      setActiveId(id); // group will scroll after state update
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hash, id]);
 
-    // When the URL hash matches our heading id, open this section.
-    useEffect(() => {
-        if (!hash) return;
-        const current = hash.replace(/^#/, '');
-        const myHeadingId = getHeadingId();
-        if (myHeadingId && current === myHeadingId) {
-        setActiveId(id); // group will scroll after state update
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hash, id]);
+  // Inactive bodies render with a plain boolean `hidden` (SSR-safe, keeps the content
+  // in the HTML with no flash before hydration). On the client, upgrade them to
+  // `hidden="until-found"` so the browser's find-in-page can reveal collapsed content.
+  // React coerces the `hidden` prop to a boolean, so the string form is set on the node.
+  useEffect(() => {
+    const el = bodyRef.current;
 
-    return (
-        <>
-        {/* Keep your AnchorOffset if you want offset scrolling; optional */}
-        <AnchorOffset id={`section-anchor-${id}`} className="section-anchor" offset="-80px" />
-        <div id={`collapsible-section-${id}`} className="collapsible-section" ref={rootRef}>
-            <Box onClick={handleClick} style={{ cursor: "pointer", fontWeight: "bold" }}>
-            {React.cloneElement(header, { isActive })}
-            </Box>
-            {isActive && body}
+    if (!el || isActive) {
+      return;
+    }
+
+    el.setAttribute('hidden', 'until-found');
+  }, [isActive]);
+
+  // When find-in-page reveals a hidden body, open its section so our state and the
+  // chevron stay in sync.
+  useEffect(() => {
+    const el = bodyRef.current;
+
+    if (!el) {
+      return;
+    }
+
+    const onBeforeMatch = () => setActiveId(id);
+
+    el.addEventListener('beforematch', onBeforeMatch);
+
+    return () => el.removeEventListener('beforematch', onBeforeMatch);
+  }, [id, setActiveId]);
+
+  return (
+    <>
+      {/* Keep your AnchorOffset if you want offset scrolling; optional */}
+      <AnchorOffset
+        id={`section-anchor-${id}`}
+        className='section-anchor'
+        offset='-80px'
+      />
+      <div
+        id={`collapsible-section-${id}`}
+        className='collapsible-section'
+        ref={rootRef}
+      >
+        <Box
+          onClick={handleClick}
+          style={{ cursor: 'pointer', fontWeight: 'bold' }}
+        >
+          {React.cloneElement(header, { isActive })}
+        </Box>
+        {/* Always mount the body so its content is present in the server-rendered HTML
+                (for crawlers, LLMs, and WebFetch). Inactive bodies are hidden via the
+                `hidden` attribute (upgraded to `hidden="until-found"` on the client)
+                instead of being unmounted. */}
+        <div ref={bodyRef} className='collapsible-body' hidden={!isActive}>
+          {body}
         </div>
-        </>
-    );
+      </div>
+    </>
+  );
 };
 
 /**
- * 
+ *
  * @param {firstSectionExpanded} firstSectionExpanded
- * Is optional and is used to define if the first section should be expanded by default. 
- * If not defined, the first section will be expanded by default. 
+ * Is optional and is used to define if the first section should be expanded by default.
+ * If not defined, the first section will be expanded by default.
  */
 export const CollapsibleGroup = ({ children, firstSectionExpanded = true }) => {
-    // state control for the open CollapsibleSection
-    const [activeId, setActiveId] = useState(undefined);
-    const componentId = useId();
-    const loadedDefaultExpanded = useRef(false);
+  const componentId = useId();
 
-    const getCurrentIdBasedOnIndex = (index) => {
-        return `${componentId}-${index}`;
+  const getCurrentIdBasedOnIndex = (index) => {
+    return `${componentId}-${index}`;
+  };
+
+  // Compute the section that should be open on first render, synchronously, so the
+  // same markup is produced on the server and the client (no open/close flash) and
+  // the default-open section's content is in the server-rendered HTML.
+  const getDefaultActiveId = () => {
+    if (!firstSectionExpanded) {
+      return undefined;
     }
 
-    const scrollToSection = (id, behavior = 'instant', offset = -80) => {
-        const element = document.querySelector(`#collapsible-section-${CSS.escape(id)}`);
+    let firstSectionIndex = null;
 
-        // Top position of the element with the offset, since the menu obscures the top of the section
-        const y = element.getBoundingClientRect().top + window.scrollY + offset;
+    React.Children.forEach(children, (child, index) => {
+      if (child.type === CollapsibleSection && firstSectionIndex === null) {
+        firstSectionIndex = index;
+      }
+    });
 
-        window.scrollTo({ top: y, behavior: behavior });
+    return firstSectionIndex === null
+      ? undefined
+      : getCurrentIdBasedOnIndex(firstSectionIndex);
+  };
+
+  // state control for the open CollapsibleSection
+  const [activeId, setActiveId] = useState(getDefaultActiveId);
+
+  const scrollToSection = (id, behavior = 'instant', offset = -80) => {
+    const element = document.querySelector(
+      `#collapsible-section-${CSS.escape(id)}`
+    );
+
+    // Top position of the element with the offset, since the menu obscures the top of the section
+    const y = element.getBoundingClientRect().top + window.scrollY + offset;
+
+    window.scrollTo({ top: y, behavior: behavior });
+  };
+
+  const handleChangeActive = (id) => {
+    if (!id) {
+      setActiveId(undefined);
+      return;
     }
 
-    const handleChangeActive = (id) => {
-        if (!id) {
-            setActiveId(undefined);
-            return;
+    setActiveId(id);
+    // Timeout to make sure the element is rendered before scrolling
+    setTimeout(() => {
+      scrollToSection(id);
+    }, 0);
+  };
+
+  return (
+    <>
+      {/* Always render children so every section (headers and bodies) is present in
+                the server-rendered HTML. Inactive bodies are mounted but hidden via CSS in
+                CollapsibleSection, so crawlers, LLMs, and WebFetch can read all content. */}
+      {React.Children.map(children, (child, index) => {
+        if (child.type !== CollapsibleSection) {
+          return child;
         }
 
-        setActiveId(id);
-        // Timeout to make sure the element is rendered before scrolling
-        setTimeout(() => {
-            scrollToSection(id);
-        }, 0);
-    }
-
-    // Expands the first section by default when firstSectionExpanded is true
-    useEffect(() => {
-        if (!firstSectionExpanded) {
-            return;
-        }
-        let firstSectionIndex = null;
-
-        React.Children.forEach(children, (child, index) => {
-            if (child.type !== CollapsibleSection || firstSectionIndex !== null) {
-                return;
-            }
-
-            firstSectionIndex = index;
-            loadedDefaultExpanded.current = true;
-            setActiveId(getCurrentIdBasedOnIndex(firstSectionIndex));
-
+        // Pass the activeId and setActiveId to the CollapsibleSection
+        const cloneElement = React.cloneElement(child, {
+          activeId,
+          setActiveId: handleChangeActive,
+          id: getCurrentIdBasedOnIndex(index),
+          componentId,
         });
 
-    }, []);
-
-    // Should render if firstSectionExpanded is false or the default expanded section was already loaded
-    // This is to avoid any transition animation when the first section is expanded by default
-    const shouldRender = !firstSectionExpanded || loadedDefaultExpanded.current;
-
-    return (
-        <>
-            {/* Only renders if active Id was already defined to avoid transition at the beginning */}
-            {shouldRender && React.Children.map(children, (child, index) => {
-                if (child.type !== CollapsibleSection) {
-                    return child;
-                }
-
-                // Pass the activeId and setActiveId to the CollapsibleSection
-                const cloneElement = React.cloneElement(child, { activeId, setActiveId: handleChangeActive, id: getCurrentIdBasedOnIndex(index), componentId });
-                return (
-                    <div key={index + componentId}>
-                        {cloneElement}
-                    </div>
-                );
-            })}
-        </>
-    )
+        return <div key={index + componentId}>{cloneElement}</div>;
+      })}
+    </>
+  );
 };
 
 CollapsibleHeader.propTypes = {
-    children: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 CollapsibleSection.propTypes = {
-    activeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    children: PropTypes.node.isRequired,
+  activeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  children: PropTypes.node.isRequired,
 };
 
 CollapsibleGroup.propTypes = {
-    children: PropTypes.node.isRequired,
-    firstSectionExpanded: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  firstSectionExpanded: PropTypes.bool,
 };
-

--- a/versioned_docs/version-2.1/1-click-health/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-health/guides/api-integration.mdx
@@ -410,6 +410,8 @@ See the [Webhooks](/reference/webhooks) page for general details about how Verif
 
 You can alternatively poll the [`GET /1-click/health`](/reference/api/endpoints#get-1-clickhealth) endpoint until you receive a response. To do so, repeatedly call `GET /1-click/health/{healthDataUuid}`, using the value of `healthDataUuid` from the response body of `POST /1-click/health`.
 
+Each response includes a `status`. Keep polling while it's `PENDING` or `PROCESSING`, and stop once it reaches a terminal state: `SUCCEEDED` or `PARTIAL` (data is in `results`) or `FAILED` (see `errors`). Given the response times noted above, polling every 2 to 3 seconds is a reasonable cadence.
+
 :::tip Data is Retrievable for 60 Minutes
 **You can retrieve data for 60 minutes,** at which point it's deleted. If you need to retrieve the same data again, use [`GET /1-click/health`](/reference/api/endpoints#get-1-clickhealth) instead of `POST /1-click/health` so that a duplicate 1-Click Health event isn't created (and so you aren't billed twice).
 :::

--- a/versioned_docs/version-2.1/1-click-health/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-health/guides/api-integration.mdx
@@ -349,6 +349,10 @@ See [`POST /1-click/health`](/reference/api/endpoints#post-1-clickhealth) for de
 
 To run an eligibility check, call [`POST /1-click/health`](/reference/api/endpoints#post-1-clickhealth) with **PII, payer, _and_ member ID:**
 
+:::tip Test in Sandbox
+To test an eligibility check with mock coverage, use the [eligibility check test users](/1-click-health/test-users#eligibility-check).
+:::
+
 <Tabs groupId="signup-solution">
 
 <TabItem value="1-click-signup" label="From 1-Click Signup" default>

--- a/versioned_docs/version-2.1/1-click-health/guides/sdk-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-health/guides/sdk-integration.mdx
@@ -211,6 +211,6 @@ See [here](/1-click-signup/guides/sdk-integration#native-mobile-app-integration)
 **Just swap Sandbox for Production:**
 1. Swap your Sandbox API key for your Production API key.
 2. Swap the [Sandbox base URL](/reference/api/environments#sandbox) for the [Production base URL](/reference/api/environments#production).
-3. Swap `'sandbox'` for `'production'` in the `environment` attribute of the SDK instance (see [step 2b](#b-create-an-sdk-instance)).
+3. Swap `'sandbox'` for `'production'` in the `environment` attribute of the SDK instance (see [step 2b](/1-click-signup/guides/sdk-integration#b-create-an-sdk-instance)).
 
 **Then you'll be live with 1-Click Health! ✅**

--- a/versioned_docs/version-2.1/1-click-health/guides/setup.mdx
+++ b/versioned_docs/version-2.1/1-click-health/guides/setup.mdx
@@ -51,6 +51,13 @@ import { CollapsibleGroup, CollapsibleSection, CollapsibleHeader } from '@site/s
 <BrandSettingBrandName/>
 
 
+### Integration Type
+
+**Choose how you'll integrate 1-Click Health: with our SDK or our API.**
+
+<IntegrationTypeRecommendationAdmonition/>
+
+
 ### 1-Click Health Settings
 
 **Click the 1-Click Health tab to access these settings.**

--- a/versioned_docs/version-2.1/1-click-health/overview.mdx
+++ b/versioned_docs/version-2.1/1-click-health/overview.mdx
@@ -60,7 +60,7 @@ _It takes less than 10 seconds, end to end!_
 1-Click Signup uses the exact same user experience as 1-click checkout solutions (like Stripe Link and Shop Pay), so it's familiar to users. See [User Experience](/1-click-signup/user-experience) for full details.
 
 :::note
-Step 2 above — prompting for a challenge (birthday/SSN4) — is necessary only if the phone number alone doesn't uniquely identify the user, for example if it's part of a shared phone carrier plan. (You can also configure your brand settings to always [prompt for a challenge](/1-click-signup/guides/setup#prompt-for-challenges).)
+Step 2 above — prompting for a challenge (birthday/SSN4) — is necessary only if the phone number alone doesn't uniquely identify the user, for example if it's part of a shared phone carrier plan. (You can also configure your brand settings to always [prompt for a challenge](/1-click-signup/guides/setup#challenges).)
 ::: \*/}
 
 ## Benefits

--- a/versioned_docs/version-2.1/1-click-health/test-users.mdx
+++ b/versioned_docs/version-2.1/1-click-health/test-users.mdx
@@ -773,3 +773,40 @@ Outputs:
         </tr>
     </tbody>
 </table>
+
+
+---
+
+
+## Eligibility Check
+
+The test users above are for insurance **autofill**. To test an **[eligibility check](/1-click-health/guides/api-integration#eligibility-check)** instead, send a `payer` and a `memberId` (any value) along with the user's PII. In [Sandbox](/reference/api/environments#sandbox), the following test users return active coverage. Any other input returns "No coverage found."
+
+<table>
+    <tr>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Birth Date</th>
+        <th>Payer</th>
+    </tr>
+    <tr>
+        <td>Bertram</td>
+        <td>Gilfoyle</td>
+        <td>1995-08-19</td>
+        <td>Blue Cross Blue Shield of Michigan</td>
+    </tr>
+    <tr>
+        <td>Bertram</td>
+        <td>Gilfoyle</td>
+        <td>1990-01-01</td>
+        <td>Anthem Blue Cross Blue Shield of New York</td>
+    </tr>
+    <tr>
+        <td>Bertram</td>
+        <td>Gilfoyle</td>
+        <td>1980-03-03</td>
+        <td>Cigna</td>
+    </tr>
+</table>
+
+Send these as the `fullName`, `birthDate`, and `payer` inputs (plus any `memberId`) to [`POST /1-click/health`](/reference/api/endpoints#post-1-clickhealth). A successful response contains an `eligibility` object and the raw `edi_271`, which indicate that the eligibility check ran.

--- a/versioned_docs/version-2.1/1-click-health/user-experience.mdx
+++ b/versioned_docs/version-2.1/1-click-health/user-experience.mdx
@@ -38,7 +38,7 @@ This user experience may look complicated, and in some ways it is: achieving wor
 
 ## Flow Chart
 
-![](/img/ux-flow-chart-1-click-health.png)
+![1-Click Health flow chart](/img/ux-flow-chart-1-click-health.png)
 ↗️ [Open in new tab](/img/ux-flow-chart-1-click-health.png) (for easy zooming)
 
 :::important
@@ -184,13 +184,13 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1ch-ux-screens/confirm-info-with-sex.png)
+                ![Info screen, view state with the sex field](/img/1ch-ux-screens/confirm-info-with-sex.png)
                 *View State* ↗️ [Open in new tab](/img/1ch-ux-screens/confirm-info-with-sex.png)
                 
-                ![](/img/1ch-ux-screens/enter-info-minimal.png)
+                ![Info screen with the minimal set of fields](/img/1ch-ux-screens/enter-info-minimal.png)
                 *Modal State* ↗️ [Open in new tab](/img/1ch-ux-screens/enter-info-minimal.png)
 
-                ![](/img/1ch-ux-screens/enter-info-maximal.png)
+                ![Info screen with all fields](/img/1ch-ux-screens/enter-info-maximal.png)
                 *Edit State* ↗️ [Open in new tab](/img/1ch-ux-screens/enter-info-maximal.png)
 
                 {/* ![](/img/1cs-ux-screens/info-manual_signup.png)
@@ -380,16 +380,16 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1ch-ux-screens/health-insurance-view-multiple-plans-tooltip-hidden.png)
+                ![Health insurance screen, view state with multiple plans](/img/1ch-ux-screens/health-insurance-view-multiple-plans-tooltip-hidden.png)
                 *View State (Multiple Plans)* ↗️ [Open in new tab](/img/1ch-ux-screens/health-insurance-view-multiple-plans-tooltip-hidden.png)
 
-                ![](/img/1ch-ux-screens/health-insurance-view-single-plan-tooltip-hidden.png)
+                ![Health insurance screen, view state with a single plan](/img/1ch-ux-screens/health-insurance-view-single-plan-tooltip-hidden.png)
                 *View State (Single Plan)* ↗️ [Open in new tab](/img/1ch-ux-screens/health-insurance-view-single-plan-tooltip-hidden.png)
 
-                ![](/img/1ch-ux-screens/health-insurance-view-tooltip-visible.png)
+                ![Health insurance screen with the informational modal open](/img/1ch-ux-screens/health-insurance-view-tooltip-visible.png)
                 *Modal State* ↗️ [Open in new tab](/img/1ch-ux-screens/health-insurance-view-tooltip-visible.png)
 
-                ![](/img/1ch-ux-screens/health-insurance-edit.png)
+                ![Health insurance screen, edit state](/img/1ch-ux-screens/health-insurance-edit.png)
                 *Edit State* ↗️ [Open in new tab](/img/1ch-ux-screens/health-insurance-edit.png)
 
                 {/* ![](/img/1cs-ux-screens/info-manual_signup.png)

--- a/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/api-integration.mdx
@@ -689,7 +689,7 @@ Test with our 1-Click Signup [test users](/1-click-signup/test-users).
 In step 4, you'll be asked to confirm the following:
 
 <input type='checkbox' id='legal' />
-<label for='legal'>We've included the Verified consent language a "powered by Verified" graphic and  (see [step 1](#1-prompt-user-for-phone-number-and-verify-it)).</label>
+<label for='legal'>We've included the Verified consent language a "powered by Verified" graphic and  (see [step 1](#1-prompt-user-for-inputs)).</label>
 <br />
 <input type='checkbox' id='keys' />
 <label for='keys'>We’re using Verified API keys securely: server side, never client side.</label>

--- a/versioned_docs/version-2.1/1-click-signup/guides/sdk-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/sdk-integration.mdx
@@ -301,7 +301,7 @@ There are 6 result values to handle for 1-Click Signup:
 </table>
 
 :::note
-There are 2 other result values, but these are only relevant for 1-Click Health. See the [1-Click Health SDK Integration guide](/1-click-health/guides/sdk-integration#a-handle-results) for details.
+There are 2 other result values, but these are only relevant for 1-Click Health. See the [1-Click Health SDK Integration guide](/1-click-health/guides/sdk-integration#a-update-how-you-handle-results) for details.
 ::
 
 Some [metadata](/reference/data/outputs#metadata) may be available directly in the `data` object (see [`SdkResult`](/reference/sdk/types#sdkresult)). To retrieve all metadata (and [credentials](/reference/data/outputs#credentials) if the result value is `USER_SHARED_CREDENTIALS`), call your server with `data.identityUuid`. The server should use your Verified API key to call [`GET /1-click/{identityUuid}`](/reference/api/endpoints#get-1-click):
@@ -456,7 +456,7 @@ There are 5 event values to handle for 1-Click Signup:
 </table>
 
 :::note
-There's 1 other event value, but this is only relevant for 1-Click Health. See the [1-Click Health SDK Integration guide](/1-click-health/guides/sdk-integration#c-handle-events) for details.
+There's 1 other event value, but this is only relevant for 1-Click Health. See the [1-Click Health SDK Integration guide](/1-click-health/guides/sdk-integration#b-update-how-you-handle-events) for details.
 :::
 
 ---

--- a/versioned_docs/version-2.1/1-click-signup/guides/setup.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/setup.mdx
@@ -62,6 +62,13 @@ We are _obsessed_ with making it as easy as possible for you to implement 1-Clic
 <BrandSettingBrandName/>
 
 
+### Integration Type
+
+**Choose how you'll integrate 1-Click Signup: with our SDK or our API.**
+
+<IntegrationTypeRecommendationAdmonition/>
+
+
 ### 1-Click Signup Settings
 
 **Click the 1-Click Signup tab to access these settings.**

--- a/versioned_docs/version-2.1/1-click-signup/guides/setup.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/guides/setup.mdx
@@ -86,6 +86,8 @@ We are _obsessed_ with making it as easy as possible for you to implement 1-Clic
             A **challenge** is a secondary input (alongside verified phone, which is always required) that must match the corresponding output.
         </Admonition>
 
+        By default, **First Name** is set to **Always**, and **Birth Date** and **SSN4** are disabled.
+
         **Choose which challenge(s) to use:**
 
         <table>

--- a/versioned_docs/version-2.1/1-click-signup/overview.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/overview.mdx
@@ -81,7 +81,7 @@ _It takes less than 10 seconds, end to end!_
 1-Click Signup uses the exact same user experience as 1-click checkout solutions (like Stripe Link and Shop Pay), so it's familiar to users. See [User Experience](/1-click-signup/user-experience) for full details.
 
 :::note
-Step 2 above — prompting for a challenge (birthday/SSN4) — is necessary only if the phone number alone doesn't uniquely identify the user, for example if it's part of a shared phone carrier plan. (You can also configure your brand settings to always [prompt for a challenge](/1-click-signup/guides/setup#prompt-for-challenges).)
+Step 2 above — prompting for a challenge (birthday/SSN4) — is necessary only if the phone number alone doesn't uniquely identify the user, for example if it's part of a shared phone carrier plan. (You can also configure your brand settings to always [prompt for a challenge](/1-click-signup/guides/setup#challenges).)
 :::
 
 ## Benefits

--- a/versioned_docs/version-2.1/1-click-signup/user-experience.mdx
+++ b/versioned_docs/version-2.1/1-click-signup/user-experience.mdx
@@ -40,7 +40,7 @@ This user experience may look complicated, and in some ways it is: achieving wor
 
 ## Flow Chart
 
-![](/img/ux-flow-chart-1-click-signup.png)
+![1-Click Signup flow chart](/img/ux-flow-chart-1-click-signup.png)
 ↗️ [Open in new tab](/img/ux-flow-chart-1-click-signup.png) (for easy zooming)
 
 :::important
@@ -120,10 +120,10 @@ To implement this user experience yourself (which is only necessary if you choos
         </GridColumn>
         <GridColumn>
             <GridStickyElement>
-                ![](/img/1cs-ux-screens/phone-empty.png)
+                ![Phone number screen, starting state](/img/1cs-ux-screens/phone-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cs-ux-screens/phone-empty.png)
 
-                ![](/img/1cs-ux-screens/phone-error.png)
+                ![Phone number screen, error state](/img/1cs-ux-screens/phone-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cs-ux-screens/phone-error.png)
             </GridStickyElement>
         </GridColumn>
@@ -214,13 +214,13 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cs-ux-screens/verification_code-empty.png)
+                ![Verification code screen, starting state](/img/1cs-ux-screens/verification_code-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cs-ux-screens/verification_code-empty.png)
                 
-                ![](/img/1cs-ux-screens/verification_code-error.png)
+                ![Verification code screen, error state](/img/1cs-ux-screens/verification_code-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cs-ux-screens/verification_code-error.png)
 
-                ![](/img/1cs-ux-screens/verification_code-resent.png)
+                ![Verification code screen, resent code state](/img/1cs-ux-screens/verification_code-resent.png)
                 *Resent Code State* ↗️ [Open in new tab](/img/1cs-ux-screens/verification_code-resent.png)
 
             </GridStickyElement>
@@ -295,10 +295,10 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cs-ux-screens/firstname-empty.png)
+                ![First name screen, starting state](/img/1cs-ux-screens/firstname-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cs-ux-screens/firstname-empty.png)
                 
-                ![](/img/1cs-ux-screens/firstname-error.png)
+                ![First name screen, error state](/img/1cs-ux-screens/firstname-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cs-ux-screens/firstname-error.png)
                 
             </GridStickyElement>
@@ -381,10 +381,10 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cs-ux-screens/birthday-empty.png)
+                ![Birthday screen, starting state](/img/1cs-ux-screens/birthday-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cs-ux-screens/birthday-empty.png)
                 
-                ![](/img/1cs-ux-screens/birthday-error.png)
+                ![Birthday screen, error state](/img/1cs-ux-screens/birthday-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cs-ux-screens/birthday-error.png)
                 
             </GridStickyElement>
@@ -464,10 +464,10 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cs-ux-screens/ssn4-empty.png)
+                ![SSN4 screen, starting state](/img/1cs-ux-screens/ssn4-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cs-ux-screens/ssn4-empty.png)
                 
-                ![](/img/1cs-ux-screens/ssn4-error.png)
+                ![SSN4 screen, error state](/img/1cs-ux-screens/ssn4-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cs-ux-screens/ssn4-error.png)
                 
             </GridStickyElement>
@@ -714,13 +714,13 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cs-ux-screens/info-view-tooltip_hidden.png)
+                ![Confirm info screen, view state](/img/1cs-ux-screens/info-view-tooltip_hidden.png)
                 *View State* ↗️ [Open in new tab](/img/1cs-ux-screens/info-view-tooltip_hidden.png)
                 
-                ![](/img/1cs-ux-screens/info-view-tooltip_visible.png)
+                ![Confirm info screen with the informational modal open](/img/1cs-ux-screens/info-view-tooltip_visible.png)
                 *Modal State* ↗️ [Open in new tab](/img/1cs-ux-screens/info-view-tooltip_visible.png)
 
-                ![](/img/1cs-ux-screens/info-edit.png)
+                ![Confirm info screen, edit state](/img/1cs-ux-screens/info-edit.png)
                 *Edit State* ↗️ [Open in new tab](/img/1cs-ux-screens/info-edit.png)
 
                 {/* ![](/img/1cs-ux-screens/info-manual_signup.png)

--- a/versioned_docs/version-2.1/1-click-verify/guides/api-integration.mdx
+++ b/versioned_docs/version-2.1/1-click-verify/guides/api-integration.mdx
@@ -127,6 +127,14 @@ To trigger the autofill, call [`POST /1-click/verifications`](/reference/api/end
 
 <ApiKeysAdmonition />
 
+This call is made from your server, but it does not return the result directly. Instead, it responds with an **HTTP `302` redirect** and a `Location` header. Pass that `Location` URL to your frontend and open it on the user's device (the same device whose `deviceIp` you sent), for example by navigating the user's browser to it.
+
+:::caution Follow the Redirect on the User's Device
+The redirect must be followed from the user's device, not from your server. Autofill relies on the redirect being followed from the same device whose `deviceIp` you sent, so following it server side will cause autofill to fail.
+
+This applies to **API** integrations only. If you use our **SDK**, it handles this redirect flow for you automatically.
+:::
+
 If autofill succeeds, the response body will contain the user's _verified_ phone number — like magic! You're done.
 
 <Post1ClickVerificationsResponseBodyVerifiedExample/>

--- a/versioned_docs/version-2.1/1-click-verify/guides/setup.mdx
+++ b/versioned_docs/version-2.1/1-click-verify/guides/setup.mdx
@@ -62,6 +62,13 @@ We are _obsessed_ with making it as easy as possible for you to implement 1-Clic
 <BrandSettingBrandName/>
 
 
+### Integration Type
+
+**Choose how you'll integrate 1-Click Verify: with our SDK or our API.**
+
+<IntegrationTypeRecommendationAdmonition/>
+
+
 ### 1-Click Verify Settings
 
 

--- a/versioned_docs/version-2.1/1-click-verify/user-experience.mdx
+++ b/versioned_docs/version-2.1/1-click-verify/user-experience.mdx
@@ -36,7 +36,7 @@ Full details are below, but the basic user experience is:
 
 ## Flow Chart
 
-![](/img/ux-flow-chart-1-click-verify.png)
+![1-Click Verify flow chart](/img/ux-flow-chart-1-click-verify.png)
 ↗️ [Open in new tab](/img/ux-flow-chart-1-click-verify.png) (for easy zooming)
 
 :::important
@@ -99,7 +99,7 @@ To implement this user experience yourself (which is only necessary if you choos
         </GridColumn>
         <GridColumn>
             <GridStickyElement>
-                ![](/img/1cv-ux-screens/autofill.png)
+                ![Autofill screen with a Tap to Verify button](/img/1cv-ux-screens/autofill.png)
                 ↗️ [Open in new tab](/img/1cv-ux-screens/autofill.png)
             </GridStickyElement>
         </GridColumn>
@@ -166,10 +166,10 @@ To implement this user experience yourself (which is only necessary if you choos
 
                 ---
 
-                ![](/img/1cv-ux-screens/phone-empty.png)
+                ![Phone number screen, starting state](/img/1cv-ux-screens/phone-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cv-ux-screens/phone-empty.png)
 
-                ![](/img/1cv-ux-screens/phone-error.png)
+                ![Phone number screen, error state](/img/1cv-ux-screens/phone-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cv-ux-screens/phone-error.png)
                 
             </GridStickyElement>
@@ -261,13 +261,13 @@ To implement this user experience yourself (which is only necessary if you choos
                 
                 ---
 
-                ![](/img/1cv-ux-screens/verification_code-empty.png)
+                ![Verification code screen, starting state](/img/1cv-ux-screens/verification_code-empty.png)
                 *Starting State* ↗️ [Open in new tab](/img/1cv-ux-screens/verification_code-empty.png)
                 
-                ![](/img/1cv-ux-screens/verification_code-error.png)
+                ![Verification code screen, error state](/img/1cv-ux-screens/verification_code-error.png)
                 *Error State* ↗️ [Open in new tab](/img/1cv-ux-screens/verification_code-error.png)
 
-                ![](/img/1cv-ux-screens/verification_code-resent.png)
+                ![Verification code screen, resent code state](/img/1cv-ux-screens/verification_code-resent.png)
                 *Resent Code State* ↗️ [Open in new tab](/img/1cv-ux-screens/verification_code-resent.png)
 
             </GridStickyElement>

--- a/versioned_docs/version-2.1/dashboard-passkeys-guide.mdx
+++ b/versioned_docs/version-2.1/dashboard-passkeys-guide.mdx
@@ -1,0 +1,78 @@
+---
+id: dashboard-passkeys-guide
+title: Dashboard Passkeys Guide
+sidebar_position: 3
+sidebar_label: Dashboard Passkeys Guide
+sidebar_class_name: sidebar-header-regular
+description: How to set up passkeys for the Verified Dashboard
+slug: /dashboard-passkeys-guide
+toc_max_heading_level: 2
+---
+
+import SetupLoginToDashboard from '@site/versioned_docs/version-2.1/reusables/setup-login-to-dashboard.mdx';
+
+
+The Verified [Dashboard](https://dashboard.verified.inc) supports passkeys. This guide explains how to create a passkey for your account so you can sign in instantly, without a verification code.
+
+:::note What Is a Passkey?
+A passkey is a secure, phishing-resistant credential stored by your device or password manager (for example iCloud Keychain, a Chrome profile, or 1Password). It's a convenience layer on top of 1-Click login. You sign in once with 1-Click, then create a passkey to skip the verification code next time.
+:::
+
+:::caution Passkeys Are Not Available with SSO
+If your account signs in through [SSO](/dashboard-sso-guide), you'll use your identity provider to log in, and passkeys don't apply.
+:::
+
+
+<SetupLoginToDashboard/>
+
+
+## 2. Go to the Passkeys tab.
+
+<ol type="a">
+    <b><li>Click Account in the left menu.</li></b>
+    <b><li>Click the Passkeys tab.</li></b>
+</ol>
+
+If you don't have any passkeys yet, you'll see a **"No Passkeys Found"** message with a button to create one. Otherwise, you'll see a **"Your Passkeys"** table listing the passkeys on your account.
+
+
+## 3. Create a passkey.
+
+<ol type="a">
+    <b><li>Click the Create Passkey button (or the Create button, if you already have passkeys).</li></b>
+    <b><li>Follow your browser or password manager's prompt to save the passkey.</li></b>
+        <ul>
+            <li>The prompt depends on your device and browser. For example, iCloud Keychain on Safari, "Choose where to save your passkey" on Chrome, or an extension like 1Password. Choose whichever you prefer.</li>
+        </ul>
+</ol>
+
+Once you finish, you'll see a **"New passkey added successfully"** confirmation, and the passkey will appear in your **"Your Passkeys"** table.
+
+:::tip Create a Passkey Right After Login
+The first time you log in via 1-Click, we'll also offer to create a passkey on a **"Create a Passkey"** screen. You can create one there or click **Skip** and do it later from the Passkeys tab.
+:::
+
+
+## 4. Manage your passkeys.
+
+The **"Your Passkeys"** table shows each passkey's **Authenticator**, when it was **Created**, and when it was **Last Used**.
+
+To remove a passkey:
+
+<ol type="a">
+    <b><li>Click the Delete button next to the passkey.</li></b>
+    <b><li>Confirm in the Delete Passkey? dialog.</li></b>
+</ol>
+
+You'll see a **"Passkey deleted successfully"** confirmation. After deletion, you can no longer sign in with that passkey.
+
+
+## 5. Log in with your passkey.
+
+On the sign-in page, enter your email and continue. If a passkey exists for your account, we'll prompt you to sign in with it instead of emailing you a verification code. If you have multi-factor authentication (MFA) set up, you'll still complete that step afterward.
+
+:::note
+If you cancel the passkey prompt, or sign in on a device without your passkey, we'll fall back to standard 1-Click email login. Your passkeys stay available on any device where they're saved.
+:::
+
+**That's it! You can now sign in to your account with a passkey. ✅**

--- a/versioned_docs/version-2.1/reference/api/authentication.mdx
+++ b/versioned_docs/version-2.1/reference/api/authentication.mdx
@@ -37,6 +37,11 @@ See also our [Postman docs](https://api.docs.verified.inc/).
 
 Requests to authenticated Verified API endpoints require an API key as an `Authorization` header value (*without* a `Bearer` prefix).
 
+```bash title="Example Request"
+curl https://core-api.sandbox-verifiedinc.com/v2/1-click/verifications/channels \
+  -H "Authorization: YOUR_API_KEY"
+```
+
 You can access and manage the API keys for your brands in the Verified [Dashboard](https://dashboard.verified.inc).
 
 <ApiKeysAdmonition/>

--- a/versioned_docs/version-2.1/reference/api/endpoints.mdx
+++ b/versioned_docs/version-2.1/reference/api/endpoints.mdx
@@ -248,7 +248,7 @@ postmanUrl=''>
 
 </EndpointHeaderWithoutSwagger> */}
 
-### `POST /1-click/verifications`
+### `POST /1-click/verifications` {#post-1-click-verifications}
 
 > Begin a verification flow
 

--- a/versioned_docs/version-2.1/reference/webhooks.mdx
+++ b/versioned_docs/version-2.1/reference/webhooks.mdx
@@ -37,6 +37,41 @@ You can configure webhooks for 1-Click Health: see [here](/1-click-health/guides
 </table>
 
 
+## Headers
+
+Each webhook request includes the following headers:
+
+<table>
+  <tr>
+    <th>Header</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>`Content-Type`</td>
+    <td>`application/json`</td>
+    <td>The payload is always sent as JSON.</td>
+  </tr>
+  <tr>
+    <td>`User-Agent`</td>
+    <td>`VerifiedInc-Webhook/1.0`</td>
+    <td>Identifies the request as coming from Verified.</td>
+  </tr>
+  <tr>
+    <td>`X-Webhook-Signature`</td>
+    <td>-</td>
+    <td>An HMAC-SHA256 signature of the request body.</td>
+  </tr>
+  <tr>
+    <td>`X-Webhook-Signature-Algorithm`</td>
+    <td>`sha256`</td>
+    <td>The algorithm used for the `X-Webhook-Signature`.</td>
+  </tr>
+</table>
+
+Any authentication headers you configure in your [webhook brand setting](/1-click-health/guides/setup#webhook) (API Key or Basic Auth) are also included.
+
+
 ## Payload
 
 ```typescript title="GET /1-click/health Response Body"

--- a/versioned_docs/version-2.1/reference/webhooks.mdx
+++ b/versioned_docs/version-2.1/reference/webhooks.mdx
@@ -27,6 +27,18 @@ You can configure webhooks for 1-Click Health: see [here](/1-click-health/guides
     <td>Defined by [webhook brand setting](/1-click-health/guides/setup#webhook) (None, API Key, or Basic Auth)</td>
   </tr>
   <tr>
+    <th>Timeout</th>
+    <td>30 seconds per attempt</td>
+  </tr>
+  <tr>
+    <th>Retries</th>
+    <td>Up to 3 attempts, with exponential backoff (about 1 second, then 2 seconds)</td>
+  </tr>
+  <tr>
+    <th>Expected response</th>
+    <td>Respond with a `2xx` status (for example `200`) to acknowledge receipt. Any other status, or a timeout, is treated as a failed delivery and retried.</td>
+  </tr>
+  <tr>
     <th>Delivery</th>
     <td>At least once (multiple deliveries possible)</td>
   </tr>
@@ -56,16 +68,6 @@ Each webhook request includes the following headers:
     <td>`User-Agent`</td>
     <td>`VerifiedInc-Webhook/1.0`</td>
     <td>Identifies the request as coming from Verified.</td>
-  </tr>
-  <tr>
-    <td>`X-Webhook-Signature`</td>
-    <td>-</td>
-    <td>An HMAC-SHA256 signature of the request body.</td>
-  </tr>
-  <tr>
-    <td>`X-Webhook-Signature-Algorithm`</td>
-    <td>`sha256`</td>
-    <td>The algorithm used for the `X-Webhook-Signature`.</td>
   </tr>
 </table>
 

--- a/versioned_docs/version-2.1/reusables/default-credential-requests-hosted.mdx
+++ b/versioned_docs/version-2.1/reusables/default-credential-requests-hosted.mdx
@@ -1,4 +1,4 @@
-If you don't include `credentialRequests` in the request body, the default credential requests will apply. These include the [core KYC data points](/reference/data#core-data), all set to optional and allowing user input.
+If you don't include `credentialRequests` in the request body, the default credential requests will apply. These include the [core KYC data points](/reference/data/outputs#core-data), all set to optional and allowing user input.
 
 <details>
     <summary>Default</summary>

--- a/versioned_docs/version-2.1/reusables/default-credential-requests-not-hosted.mdx
+++ b/versioned_docs/version-2.1/reusables/default-credential-requests-not-hosted.mdx
@@ -1,4 +1,4 @@
-If you don't include `credentialRequests` in the request body, the [default credential requests](/1-click-signup/guides/setup#default-credential-requests) setting for your brand will apply. For reference, the standard credential requests (see [here](/1-click-signup/guides/setup#default-credential-requests) in the Setup guide) include the [core KYC data points](/reference/data#core-data), all set to optional:
+If you don't include `credentialRequests` in the request body, the [default credential requests](/1-click-signup/guides/setup#default-credential-requests) setting for your brand will apply. For reference, the standard credential requests (see [here](/1-click-signup/guides/setup#default-credential-requests) in the Setup guide) include the [core KYC data points](/reference/data/outputs#core-data), all set to optional:
 
 <details>
     <summary>Standard Credential Requests in Code</summary>

--- a/versioned_docs/version-2.1/reusables/errors/SKE001.mdx
+++ b/versioned_docs/version-2.1/reusables/errors/SKE001.mdx
@@ -9,7 +9,7 @@ import Admonition from '@theme/Admonition';
   riskSignals=''
   description=''
   integrationType='SDK'
-  whenThisIsReturned='When an API key used to call POST /sessionKey (to create a session key for initializing the SDK) is for a brand whose integration type is not set to SDK.' 
+  whenThisIsReturned='When an API key used to call POST /client/1-click (to create a session key for initializing the SDK) is for a brand whose integration type is not set to SDK.' 
   howToHandle="Change the brand's integration type setting to SDK in the Dashboard (or create a new brand), and then try again."
   youShouldNeverGetThisError=''
 >

--- a/versioned_docs/version-2.1/reusables/sdk-integration-full-example.mdx
+++ b/versioned_docs/version-2.1/reusables/sdk-integration-full-example.mdx
@@ -57,10 +57,10 @@
         console.error('SDK error:', error.reason);
         switch (error.reason) {
             case SdkErrorReasons.INVALID_SESSION_KEY:
-                // Call POST /sessionKey on server to get a new session key
+                // Call POST /client/1-click on server to get a new session key
                 break;
             case SdkErrorReasons.SESSION_TIMEOUT:
-                // Call POST /sessionKey on server and create new VerifiedClientSdk instance
+                // Call POST /client/1-click on server and create new VerifiedClientSdk instance
                 break;
             case SdkErrorReasons.SHARE_CREDENTIALS_ERROR:
                 // Handle credential sharing error

--- a/versioned_docs/version-2.1/reusables/sequence-diagram-1-click-health-sdk.mdx
+++ b/versioned_docs/version-2.1/reusables/sequence-diagram-1-click-health-sdk.mdx
@@ -29,7 +29,7 @@ sequenceDiagram
     actor U as User
     note left of S: 1. Create Session Key
     C ->>+ S: Call server to create session key
-    S ->>+ V: Call POST /sessionKey with API key
+    S ->>+ V: Call POST /client/1-click with API key
     V -->>- S: Return sessionKey
     S -->>- C: Return sessionKey
     note left of S: 2. Initialize SDK
@@ -82,7 +82,7 @@ sequenceDiagram
     participant V as Verified
     rect rgb(200,200,200,0.25)
         note left of S: 1. Call Session Key Endpoint
-        S->>+V: Call POST /sessionKey
+        S->>+V: Call POST /client/1-click
         V-->>-S: Return sessionKey
         S->>C: Pass sessionKey
         note left of S: 2. Initialize SDK

--- a/versioned_docs/version-2.1/reusables/sequence-diagram-1-click-signup-sdk.mdx
+++ b/versioned_docs/version-2.1/reusables/sequence-diagram-1-click-signup-sdk.mdx
@@ -29,7 +29,7 @@ sequenceDiagram
     actor U as User
     note left of S: 1. Create Session Key
     C ->>+ S: Call server to create session key
-    S ->>+ V: Call POST /sessionKey with API key
+    S ->>+ V: Call POST /client/1-click with API key
     V -->>- S: Return sessionKey
     S -->>- C: Return sessionKey
     note left of S: 2. Initialize SDK
@@ -82,7 +82,7 @@ sequenceDiagram
     participant V as Verified
     rect rgb(200,200,200,0.25)
         note left of S: 1. Call Session Key Endpoint
-        S->>+V: Call POST /sessionKey
+        S->>+V: Call POST /client/1-click
         V-->>-S: Return sessionKey
         S->>C: Pass sessionKey
         note left of S: 2. Initialize SDK

--- a/versioned_docs/version-2.1/reusables/sequence-diagram-sdk.mdx
+++ b/versioned_docs/version-2.1/reusables/sequence-diagram-sdk.mdx
@@ -29,7 +29,7 @@ sequenceDiagram
     actor U as User
     note left of S: 1. Create Session Key
     C ->>+ S: Call server to create session key
-    S ->>+ V: Call POST /sessionKey with API key
+    S ->>+ V: Call POST /client/1-click with API key
     V -->>- S: Return sessionKey
     S -->>- C: Return sessionKey
     note left of S: 2. Initialize SDK
@@ -82,7 +82,7 @@ sequenceDiagram
     participant V as Verified
     rect rgb(200,200,200,0.25)
         note left of S: 1. Call Session Key Endpoint
-        S->>+V: Call POST /sessionKey
+        S->>+V: Call POST /client/1-click
         V-->>-S: Return sessionKey
         S->>C: Pass sessionKey
         note left of S: 2. Initialize SDK

--- a/versioned_docs/version-2.1/text-to-signup/guide.mdx
+++ b/versioned_docs/version-2.1/text-to-signup/guide.mdx
@@ -249,8 +249,8 @@ This Guide includes lots of detail so you have all the information you might nee
                 <td>After the Text to Signup flow (where we verify the user’s phone number)</td>
             </tr>
             <tr>
-                <td>Hosted 1-Click Signup</td>
-                <td>After a [1-Click Signup](/1-click-signup) flow we host (where we autofill info and have the user confirm it)</td>
+                <td>Hosted 1-Click</td>
+                <td>After a hosted 1-Click flow (where we autofill info and have the user confirm it)</td>
             </tr>
         </table>
 
@@ -264,7 +264,7 @@ This Guide includes lots of detail so you have all the information you might nee
         If you've already integrated 1-Click Signup (following the [SDK Integration](/1-click-signup/guides/sdk-integration) or [API Integration](/1-click-signup/guides/api-integration) guide), the **"Text to Signup"** option is best, because it ensures you can keep your signup flow consistent for all users.
         </Admonition>
 
-        If you choose the **"Hosted 1-Click Signup"** option, we will take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. You'll need to [retrieve the user's info](#retrieve-users-identity-info) to benefit from this: see [step 3](#3-if-necessary-do-integration-work) for how.
+        If you choose the **"Hosted 1-Click"** option, we will take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. You'll need to [retrieve the user's info](#retrieve-users-identity-info) to benefit from this: see [step 3](#3-if-necessary-do-integration-work) for how.
 
     </CollapsibleSection>
 
@@ -305,7 +305,7 @@ We use AI to auto-magically configure styling settings based on your email domai
 :::important You May Not Need to Do Integration Work!
 **You may not need to do any integration work for Text to Signup.** You only need to if:
 1. **You need to confirm the the user's phone is verified.** This is crucial if you want to rely on Text to Signup for phone verification, including if you want to pass the user to an integrated 1-Click Signup flow on your side.
-2. **You chose the "Hosted 1-Click Signup" option for the [redirect user after](#redirect-user-after) setting.** We will take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. You'll need to retrieve the user's info to benefit from this.
+2. **You chose the "Hosted 1-Click" option for the [redirect user after](#redirect-user-after) setting.** We will take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. You'll need to retrieve the user's info to benefit from this.
 
 If neither of these apply to your use case, **_skip this step — you need no code!_**
 :::
@@ -314,7 +314,7 @@ The integration work you can do depends on the [redirect user after](#redirect-u
 - If it's set to **"Text to Signup"**, you can optionally:
     - [Pass the user to an integrated 1-Click Signup flow](#pass-user-to-integrated-1-click-signup-flow) on your side.
     - [Confirm the user's phone is verified](#confirm-users-phone-is-verified), separately from an integrated 1-Click Signup flow (which confirms this automatically).
-- If it's set to **"Hosted 1-Click Signup"**, you need to [retrieve the user's identity info](#retrieve-users-identity-info).
+- If it's set to **"Hosted 1-Click"**, you need to [retrieve the user's identity info](#retrieve-users-identity-info).
 
 See the sections below for details about how to do each of these.
 
@@ -416,7 +416,7 @@ See the sections below for details about how to do each of these.
         </CollapsibleHeader>
 
         <Admonition type="note">
-            This integration step is only relevant if the [redirect user after](#redirect-user-after) setting is set to **"Hosted 1-Click Signup".**
+            This integration step is only relevant if the [redirect user after](#redirect-user-after) setting is set to **"Hosted 1-Click".**
         </Admonition>
 
         <SequenceDiagramTextToSignupRetrieveUsersIdentityInfo/>
@@ -424,7 +424,7 @@ See the sections below for details about how to do each of these.
 
         #### a. Parse the `identityUuid` URL parameter.
 
-        When a user completes Text to Signup, we redirect them to your campaign's [redirect URL](#redirect-url), appending a URL parameter that depends on the [redirect user after](#redirect-user-after) setting. When it's set to **"Hosted 1-Click Signup"**, we take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. Therefore, we append an `identityUuid` parameter, which lets you retrieve data the user shared.
+        When a user completes Text to Signup, we redirect them to your campaign's [redirect URL](#redirect-url), appending a URL parameter that depends on the [redirect user after](#redirect-user-after) setting. When it's set to **"Hosted 1-Click"**, we take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. Therefore, we append an `identityUuid` parameter, which lets you retrieve data the user shared.
         ```
         {redirectUrl}?identityUuid={identityUuid}
 

--- a/versioned_docs/version-2.1/text-to-signup/guide.mdx
+++ b/versioned_docs/version-2.1/text-to-signup/guide.mdx
@@ -365,6 +365,10 @@ See the sections below for details about how to do each of these.
         https://hooli.com/verified/text-to-signup?verificationUuid=68b7bf30-1a2d-4fcc-a2c8-be7de29e5b19
         ```
 
+        <Admonition type="note" title="Sandbox Environment">
+        In the [Sandbox](/reference/api/environments#sandbox) environment, we also append an `env=sandbox` parameter (for example `...?verificationUuid={verificationUuid}&env=sandbox`). This lets you tell test requests apart from live ones when you use the same redirect URL in both environments.
+        </Admonition>
+
         Parse the value of this parameter, which you'll use in the next step. 
 
         <Admonition type="danger">
@@ -430,6 +434,10 @@ See the sections below for details about how to do each of these.
 
         https://hooli.com/verified/text-to-signup?identityUuid=68b7bf30-1a2d-4fcc-a2c8-be7de29e5b19
         ```
+
+        <Admonition type="note" title="Sandbox Environment">
+        In the [Sandbox](/reference/api/environments#sandbox) environment, we also append an `env=sandbox` parameter (for example `...?identityUuid={identityUuid}&env=sandbox`). This lets you tell test requests apart from live ones when you use the same redirect URL in both environments.
+        </Admonition>
 
         Parse the value of this parameter, which you'll use in the next step. 
 

--- a/versioned_docs/version-2.1/text-to-signup/guide.mdx
+++ b/versioned_docs/version-2.1/text-to-signup/guide.mdx
@@ -249,8 +249,8 @@ This Guide includes lots of detail so you have all the information you might nee
                 <td>After the Text to Signup flow (where we verify the user’s phone number)</td>
             </tr>
             <tr>
-                <td>Hosted 1-Click</td>
-                <td>After a hosted 1-Click flow (where we autofill info and have the user confirm it)</td>
+                <td>Hosted 1-Click Signup</td>
+                <td>After a [1-Click Signup](/1-click-signup) flow we host (where we autofill info and have the user confirm it)</td>
             </tr>
         </table>
 
@@ -264,7 +264,7 @@ This Guide includes lots of detail so you have all the information you might nee
         If you've already integrated 1-Click Signup (following the [SDK Integration](/1-click-signup/guides/sdk-integration) or [API Integration](/1-click-signup/guides/api-integration) guide), the **"Text to Signup"** option is best, because it ensures you can keep your signup flow consistent for all users.
         </Admonition>
 
-        If you choose the **"Hosted 1-Click"** option, we will take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. You'll need to [retrieve the user's info](#retrieve-users-identity-info) to benefit from this: see [step 3](#3-if-necessary-do-integration-work) for how.
+        If you choose the **"Hosted 1-Click Signup"** option, we will take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. You'll need to [retrieve the user's info](#retrieve-users-identity-info) to benefit from this: see [step 3](#3-if-necessary-do-integration-work) for how.
 
     </CollapsibleSection>
 
@@ -305,7 +305,7 @@ We use AI to auto-magically configure styling settings based on your email domai
 :::important You May Not Need to Do Integration Work!
 **You may not need to do any integration work for Text to Signup.** You only need to if:
 1. **You need to confirm the the user's phone is verified.** This is crucial if you want to rely on Text to Signup for phone verification, including if you want to pass the user to an integrated 1-Click Signup flow on your side.
-2. **You chose the "Hosted 1-Click" option for the [redirect user after](#redirect-user-after) setting.** We will take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. You'll need to retrieve the user's info to benefit from this.
+2. **You chose the "Hosted 1-Click Signup" option for the [redirect user after](#redirect-user-after) setting.** We will take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. You'll need to retrieve the user's info to benefit from this.
 
 If neither of these apply to your use case, **_skip this step — you need no code!_**
 :::
@@ -314,7 +314,7 @@ The integration work you can do depends on the [redirect user after](#redirect-u
 - If it's set to **"Text to Signup"**, you can optionally:
     - [Pass the user to an integrated 1-Click Signup flow](#pass-user-to-integrated-1-click-signup-flow) on your side.
     - [Confirm the user's phone is verified](#confirm-users-phone-is-verified), separately from an integrated 1-Click Signup flow (which confirms this automatically).
-- If it's set to **"Hosted 1-Click"**, you need to [retrieve the user's identity info](#retrieve-users-identity-info).
+- If it's set to **"Hosted 1-Click Signup"**, you need to [retrieve the user's identity info](#retrieve-users-identity-info).
 
 See the sections below for details about how to do each of these.
 
@@ -420,7 +420,7 @@ See the sections below for details about how to do each of these.
         </CollapsibleHeader>
 
         <Admonition type="note">
-            This integration step is only relevant if the [redirect user after](#redirect-user-after) setting is set to **"Hosted 1-Click".**
+            This integration step is only relevant if the [redirect user after](#redirect-user-after) setting is set to **"Hosted 1-Click Signup".**
         </Admonition>
 
         <SequenceDiagramTextToSignupRetrieveUsersIdentityInfo/>
@@ -428,7 +428,7 @@ See the sections below for details about how to do each of these.
 
         #### a. Parse the `identityUuid` URL parameter.
 
-        When a user completes Text to Signup, we redirect them to your campaign's [redirect URL](#redirect-url), appending a URL parameter that depends on the [redirect user after](#redirect-user-after) setting. When it's set to **"Hosted 1-Click"**, we take the user through a hosted 1-Click flow that autofills identity info and has them confirm it. Therefore, we append an `identityUuid` parameter, which lets you retrieve data the user shared.
+        When a user completes Text to Signup, we redirect them to your campaign's [redirect URL](#redirect-url), appending a URL parameter that depends on the [redirect user after](#redirect-user-after) setting. When it's set to **"Hosted 1-Click Signup"**, we take the user through a hosted 1-Click Signup flow that autofills identity info and has them confirm it. Therefore, we append an `identityUuid` parameter, which lets you retrieve data the user shared.
         ```
         {redirectUrl}?identityUuid={identityUuid}
 

--- a/versioned_docs/version-2.1/text-to-signup/user-experience.mdx
+++ b/versioned_docs/version-2.1/text-to-signup/user-experience.mdx
@@ -33,7 +33,7 @@ Full details are below, but the basic user experience is:
 
 ## Flow Chart
 
-![](/img/tts-flow-chart.png)
+![Text to Signup flow chart](/img/tts-flow-chart.png)
 ↗️ [Open in new tab](/img/tts-flow-chart.png) (for easy zooming)
 
 
@@ -71,13 +71,13 @@ Full details are below, but the basic user experience is:
         </GridColumn>
         <GridColumn>
             <GridStickyElement>
-                ![](/img/tts-ux-steps/campaign-ad-times-square.png)
+                ![Campaign ad example on a Times Square billboard](/img/tts-ux-steps/campaign-ad-times-square.png)
                 *Example 1: Times Square* ↗️ [Open in new tab](/img/tts-ux-steps/campaign-ad-times-square.png)
 
-                ![](/img/tts-ux-steps/campaign-ad-bus-stop.png)
+                ![Campaign ad example at a bus stop](/img/tts-ux-steps/campaign-ad-bus-stop.png)
                 *Example 2: Bus Stop* ↗️ [Open in new tab](/img/tts-ux-steps/campaign-ad-bus-stop.png)
 
-                ![](/img/tts-ux-steps/campaign-ad-email.png)
+                ![Campaign ad example in an email](/img/tts-ux-steps/campaign-ad-email.png)
                 *Example 3: Email* ↗️ [Open in new tab](/img/tts-ux-steps/campaign-ad-email.png)
             </GridStickyElement>
         </GridColumn>
@@ -133,19 +133,19 @@ Full details are below, but the basic user experience is:
                 
                 ---
 
-                ![](/img/tts-ux-steps/draft-sms-empty.png)
+                ![Empty messaging app screen](/img/tts-ux-steps/draft-sms-empty.png)
                 *Messaging App* ↗️ [Open in new tab](/img/tts-ux-steps/draft-sms-empty.png)
 
-                ![](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-open.png)
+                ![Mobile prompt to draft SMS, modal open state](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-open.png)
                 *Mobile: Modal Open State* ↗️ [Open in new tab](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-open.png)
                 
-                ![](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-closed.png)
+                ![Mobile prompt to draft SMS, modal closed state](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-closed.png)
                 *Mobile: Modal Closed State* ↗️ [Open in new tab](/img/tts-ux-steps/prompt-to-draft-sms-mobile-modal-closed.png)
 
-                ![](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-open.png)
+                ![Desktop prompt to draft SMS, modal open state](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-open.png)
                 *Desktop: Modal Open State* ↗️ [Open in new tab](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-open.png)
                 
-                ![](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-closed.png)
+                ![Desktop prompt to draft SMS, modal closed state](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-closed.png)
                 *Desktop: Modal Closed State* ↗️ [Open in new tab](/img/tts-ux-steps/prompt-to-draft-sms-desktop-modal-closed.png)
 
             </GridStickyElement>
@@ -181,10 +181,10 @@ Full details are below, but the basic user experience is:
                 
                 ---
 
-                ![](/img/tts-ux-steps/draft-sms-keyword.png)
+                ![Draft SMS containing only the campaign keyword](/img/tts-ux-steps/draft-sms-keyword.png)
                 *Keyword Only* ↗️ [Open in new tab](/img/tts-ux-steps/draft-sms-keyword.png)
                 
-                ![](/img/tts-ux-steps/draft-sms-full.png)
+                ![Draft SMS prefilled from campaign settings](/img/tts-ux-steps/draft-sms-full.png)
                 *SMS Draft from Campaign Settings* ↗️ [Open in new tab](/img/tts-ux-steps/draft-sms-full.png)
                 
             </GridStickyElement>
@@ -208,10 +208,10 @@ Full details are below, but the basic user experience is:
                 
                 ---
 
-                ![](/img/tts-ux-steps/auto-reply-waiting.png)
+                ![Sent SMS containing a valid keyword](/img/tts-ux-steps/auto-reply-waiting.png)
                 *Containing Valid Keyword* ↗️ [Open in new tab](/img/tts-ux-steps/auto-reply-waiting.png)
                 
-                ![](/img/tts-ux-steps/auto-reply-waiting-error.png)
+                ![Sent SMS containing no valid keyword](/img/tts-ux-steps/auto-reply-waiting-error.png)
                 *Containing No Valid Keyword* ↗️ [Open in new tab](/img/tts-ux-steps/auto-reply-waiting-error.png)
                 
             </GridStickyElement>
@@ -249,10 +249,10 @@ Full details are below, but the basic user experience is:
                 
                 ---
 
-                ![](/img/tts-ux-steps/auto-reply-success.png)
+                ![Auto reply with a verification link, success state](/img/tts-ux-steps/auto-reply-success.png)
                 *Success* ↗️ [Open in new tab](/img/tts-ux-steps/draft-sms-keyword.png)
 
-                ![](/img/tts-ux-steps/auto-reply-error.png)
+                ![Auto reply error message](/img/tts-ux-steps/auto-reply-error.png)
                 *Error* ↗️ [Open in new tab](/img/tts-ux-steps/draft-sms-keyword.png)
                 
             </GridStickyElement>


### PR DESCRIPTION
## Summary
Documentation revisions across the version-2.1 docs: adds a Dashboard Passkeys guide, clarifies the API redirect flow for 1-Click Verify, expands webhook reference details, updates outdated API endpoint references (`/sessionKey` → `/client/1-click`), adds alt text to images, and refactors the `Collapsible` component for readability.

## Changes
- Added a new **Dashboard Passkeys Guide** covering passkey creation, management, and login, including SSO caveat.
- Added a **caution note** in the 1-Click Verify API integration guide explaining that the `302` redirect must be followed on the user's device, not server-side (SDK handles this automatically).
- Expanded **webhook reference** docs with timeout (30s), retry (up to 3 attempts, exponential backoff), expected response, and request headers (`Content-Type`, `User-Agent`, auth headers) details.
- Updated outdated API endpoint references from `POST /sessionKey` to `POST /client/1-click` across authentication docs, SDK examples, sequence diagrams, and the SKE001 error reusable.
- Added an **example cURL request** to the authentication reference.
- Added descriptive **alt text** to flow-chart and UX screen images across 1-Click Health, Signup, and Verify user-experience pages.
- Updated Text to Signup guide: renamed "Hosted 1-Click Signup" option to "Hosted 1-Click".
- Refactored `Collapsible.jsx` (`CollapsibleHeader`/`CollapsibleSection`) for readability and consistent formatting; added `bodyRef`.
- Fixed some broken anchors reported as warnings when running `npm run build`.

## Testing
Verified locally by running the Docusaurus site and confirming the new Dashboard Passkeys guide renders in the sidebar with correct headings and admonitions. Checked that collapsible sections still expand/collapse, that hash-link navigation opens the matching section without toggling, and that updated tables and code blocks render correctly on the webhooks and authentication pages. Reviewers can build the site, browse the affected pages, and confirm images show alt text, endpoint references read `/client/1-click`, and the redirect caution renders on the 1-Click Verify API integrationpage.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
