### PR TITLE
feature/eng-109-improve-supported-payers-table

### DIFF
--- a/src/components/PayerTable/PayerTable.jsx
+++ b/src/components/PayerTable/PayerTable.jsx
@@ -57,6 +57,44 @@ function SearchIcon() {
   );
 }
 
+const ELIGIBILITY_LABELS = {
+  SUPPORTED: 'Supported',
+  ENROLLMENT_REQUIRED: 'Enrollment required',
+  NOT_SUPPORTED: 'Not supported',
+};
+
+function OperatingStates({ states }) {
+  if (!Array.isArray(states) || states.length === 0) {
+    return <span className='payerCellEmpty'>—</span>;
+  }
+
+  const labels = states.includes('NATIONAL') ? ['National'] : states;
+
+  return (
+    <div className='payerChips'>
+      {labels.map((label) => (
+        <code key={label} className='payerIdChip'>
+          {label}
+        </code>
+      ))}
+    </div>
+  );
+}
+
+function EligibilityBadge({ support }) {
+  const label = ELIGIBILITY_LABELS[support];
+
+  if (!label) {
+    return <span className='payerCellEmpty'>—</span>;
+  }
+
+  return (
+    <div className='payerChips'>
+      <code className='payerIdChip'>{label}</code>
+    </div>
+  );
+}
+
 function PayerInitials({ name }) {
   const initials = (name || '?')
     .split(/\s+/)
@@ -243,6 +281,10 @@ export default function PayerTable() {
                   <SortIcon direction={sortField === 'name' ? sortDir : null} />
                 </button>
               </th>
+              <th className='payerTableTh payerTableThStates'>States</th>
+              <th className='payerTableTh payerTableThEligibility'>
+                Eligibility Check
+              </th>
               <th className='payerTableTh payerTableThIds'>
                 IDs (green indicates primary)
               </th>
@@ -261,17 +303,23 @@ export default function PayerTable() {
                   <td>
                     <div className='payerSkeleton payerSkeletonWide' />
                   </td>
+                  <td>
+                    <div className='payerSkeleton payerSkeletonWide' />
+                  </td>
+                  <td>
+                    <div className='payerSkeleton payerSkeletonWide' />
+                  </td>
                 </tr>
               ))
             ) : error ? (
               <tr style={{ border: 'none' }}>
-                <td colSpan={3} className='payerTableEmpty payerTableError'>
+                <td colSpan={4} className='payerTableEmpty payerTableError'>
                   Failed to load payers: {error}
                 </td>
               </tr>
             ) : payers.length === 0 ? (
               <tr style={{ border: 'none' }}>
-                <td colSpan={3} className='payerTableEmpty'>
+                <td colSpan={4} className='payerTableEmpty'>
                   No payers match your search.
                 </td>
               </tr>
@@ -296,6 +344,12 @@ export default function PayerTable() {
                         <code className='payerIdChip'>{row.verifiedId}</code>
                       </div>
                     </div>
+                  </td>
+                  <td className='payerTableTdStates'>
+                    <OperatingStates states={row.operatingStates} />
+                  </td>
+                  <td className='payerTableTdEligibility'>
+                    <EligibilityBadge support={row.eligibilitySupport} />
                   </td>
                   <td className='payerTableTdIds'>
                     <div className='payerIdChips'>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -715,13 +715,21 @@ table p {
 }
 
 .payerTableThName {
-  width: 60%;
+  width: 34%;
 }
 .payerTableThId {
   width: 15%;
 }
+.payerTableThStates {
+  width: 17%;
+}
+
+.payerTableThEligibility {
+  width: 13%;
+}
+
 .payerTableThIds {
-  width: 40%;
+  width: 36%;
 }
 .payerSortBtn {
   all: unset;
@@ -841,6 +849,16 @@ table p {
   color: var(--ifm-color-emphasis-700);
   white-space: nowrap;
   user-select: all;
+}
+
+.payerChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.payerCellEmpty {
+  color: var(--ifm-color-emphasis-500);
 }
 
 /* --- Empty / error states --- */


### PR DESCRIPTION
## Summary
Adds operating states and eligibility check columns to the supported payers table, so integrators can see payer coverage and eligibility support at a glance.

## Changes

- Added a **States** column rendering each payer's `operatingStates` as chips, collapsing the `NATIONAL` sentinel into a single "National" chip.
- Added an **Eligibility Check** column rendering `eligibilitySupport` as a labeled chip (Supported / Enrollment required / Not supported).
- Both columns fall back to a muted em-dash placeholder when data is missing or empty.
- Extended loading skeletons to cover the two new columns and bumped the error/empty-state `colSpan` from 3 to 4.
- Rebalanced table column widths in `custom.css` (name 60% → 34%, IDs 40% → 36%, new states 17% and eligibility 13%) and added `.payerChips` / `.payerCellEmpty` styles.

<img width="1317" height="1097" alt="image" src="https://github.com/user-attachments/assets/7ce0e459-e1cc-4cf7-afb1-cb2840068a1a" />


## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant changes to the documentation, including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added appropriate unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects.
